### PR TITLE
Update installation instructions to reduce confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ Same as youtube-webos:
 - Official YouTube app needs to be uninstalled before installation.
 
 ## Installation
-
-- Use [webOS Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel) - app is published in official webosbrew repo
-- Use [Device Manager app](https://github.com/webosbrew/dev-manager-desktop) - see [Releases](https://github.com/webosbrew/youtube-webos/releases) for a
-  prebuilt `.ipk` binary file
-- Use official webOS/webOS OSE SDK: `ares-install youtube...ipk` (for webOS SDK configuration
-  see below)
+First, build or obtain an IPK. Then install it using one of the following:
+- [Device Manager app](https://github.com/webosbrew/dev-manager-desktop) 
+- [webOS TV CLI tools](https://webostv.developer.lge.com/develop/tools/cli-installation):
+  `ares-install youtube...ipk` (for webOS CLI tools configuration see below)
 
 ## Configuration
 
@@ -164,7 +162,7 @@ Then, you can call `make PACKAGE=./your-tv-youtube.ipk` to rebuild an IPK with y
 
 ## Development TV setup
 
-### Configuring @webosose/ares-cli with Developer Mode App
+### Configuring webOS TV CLI tools with Developer Mode App
 
 This is partially based on: https://webostv.developer.lge.com/develop/app-test/using-devmode-app/
 
@@ -178,7 +176,7 @@ This is partially based on: https://webostv.developer.lge.com/develop/app-test/u
 ares-setup-device -a webos -i "username=prisoner" -i "privatekey=/path/to/downloaded/webos_rsa" -i "passphrase=PASSPHRASE" -i "host=TV_IP" -i "port=9922"
 ```
 
-### Configuring @webosose/ares-cli with Homebrew Channel / root
+### Configuring webOS TV CLI tools with Homebrew Channel / root
 
 - Enable sshd in Homebrew Channel app
 - Generate ssh key on developer machine (`ssh-keygen`)
@@ -188,8 +186,6 @@ ares-setup-device -a webos -i "username=prisoner" -i "privatekey=/path/to/downlo
 ```sh
 ares-setup-device -a webos -i "username=root" -i "privatekey=/path/to/id_rsa" -i "passphrase=SSH_KEY_PASSPHRASE" -i "host=TV_IP" -i "port=22"
 ```
-
-**Note:** @webosose/ares-cli doesn't need to be installed globally - you can use a package installed locally after `cd youtube-webos && npm install` in this repo by just prefixing above commands with local path, like so: `node_modules/.bin/ares-setup-device ...`
 
 ## Installation
 


### PR DESCRIPTION
This PR attempts to make the README less confusing (see e.g. #9) by:
* Removing the line about this being available in the "official webosbrew repo".
* Removing a link to Releases for a different repo (`webosbrew/youtube-webos`).
* Directing people to use the webOS TV CLI tools, since `ares-install` from `@webosose/ares-cli` no longer works with webOS TV.